### PR TITLE
Added PPoutput to smb module

### DIFF
--- a/odat.py
+++ b/odat.py
@@ -515,7 +515,7 @@ def main():
 	parser_usernamelikepassword = subparsers.add_parser('userlikepwd',parents=[PPoptional,PPconnection,PPusernamelikepassword,PPoutput], formatter_class=mySubFormatterClass, help='to try each Oracle username stored in the DB like the corresponding pwd')
 	parser_usernamelikepassword.set_defaults(func=runUsernameLikePassword,auditType='usernamelikepassword')
 	#2.q- smb
-	parser_smb = subparsers.add_parser('smb',parents=[PPoptional,PPconnection,PPsmb], formatter_class=mySubFormatterClass, help='to capture the SMB authentication')
+	parser_smb = subparsers.add_parser('smb',parents=[PPoptional,PPconnection,PPsmb,PPoutput], formatter_class=mySubFormatterClass, help='to capture the SMB authentication')
 	parser_smb.set_defaults(func=runSMBModule,auditType='smb')
 	#2.q- privilegeEscalation
 	parser_privilegeEscalation = subparsers.add_parser('privesc',parents=[PPoptional,PPconnection,PPprivilegeEscalation0, PPprivilegeEscalation,PPprivilegeEscalation2,PPoutput], formatter_class=mySpecialSubFormatterClass, help='to gain elevated access')


### PR DESCRIPTION
Fixes an error in the smb module that it can't find the no-color option for logging config:
```
user@localhost:~/tools/odat$ ./odat.py smb
Traceback (most recent call last):
  File "./odat.py", line 553, in <module>
    main()
  File "./odat.py", line 539, in main
    configureLogging(args)
  File "./odat.py", line 233, in configureLogging
    if args['no-color'] == False and COLORLOG_AVAILABLE==True:
KeyError: 'no-color'
```