### PR TITLE
Boolean Parameter Support

### DIFF
--- a/DbmsScheduler.py
+++ b/DbmsScheduler.py
@@ -27,7 +27,7 @@ class DbmsScheduler (OracleDatabase):
 		'''
 		logging.info('Create a job named {0}'.format(self.jobName))
 		splitCmd = cmd.split()
-		parameters = {'job_name':self.jobName,'job_type':'EXECUTABLE','job_action':splitCmd[0],'number_of_arguments':len(splitCmd)-1,'auto_drop':False}
+		parameters = {'job_name':self.jobName,'job_type':'EXECUTABLE','job_action':splitCmd[0],'number_of_arguments':len(splitCmd)-1}#,'auto_drop':False}
 		cursor = cx_Oracle.Cursor(self.args['dbcon'])
 		try :
 			if self.args['show_sql_requests'] == True: logging.info("SQL request executed: DBMS_SCHEDULER.create_job with these parameters: {0}".format(parameters))


### PR DESCRIPTION
I have tested this to work fine on Oracle 11 XE.  

Here is the issue:
The boolean parameter causes an error.
```
>>> parameters = {'job_action': '/usr/bin/python', 'number_of_arguments': 2, 'job_type': 'EXECUTABLE', 'job_name': 'test'}
>>> cur.callproc(name="DBMS_SCHEDULER.create_job",keywordParameters=parameters)
['/usr/bin/python', 2, 'EXECUTABLE', 'test']
```

If we have the boolean value
```
>>> parameters = {'job_action': '/usr/bin/python', 'number_of_arguments': 2, 'job_type': 'EXECUTABLE', 'auto_drop':False, 'job_name': 'test'}
>>> cur.callproc(name="DBMS_SCHEDULER.create_job",keywordParameters=parameters)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
cx_Oracle.DatabaseError: ORA-03115: unsupported network datatype or representation
```

Since it works fine without the auto_drop value, I would suggest to remove it.

