### PR TITLE
Bugfix arobase support in password

### DIFF
--- a/OracleDatabase.py
+++ b/OracleDatabase.py
@@ -55,12 +55,15 @@ class OracleDatabase:
         try: 
             if self.args['SYSDBA'] == True :
                 logging.debug("Connecting as SYSDBA to the database")
-                self.args['dbcon'] = cx_Oracle.connect(self.args['connectionStr'], mode=cx_Oracle.SYSDBA,threaded=threaded)
+                dsn_tns = cx_Oracle.makedsn(self.args['server'], self.args['port'], self.args['sid'])
+                self.args['dbcon'] = cx_Oracle.connect(user=self.args['user'], password=self.args['password'], mode=cx_Oracle.SYSDBA, dsn=dsn_tns,threaded=threaded)
             elif self.args['SYSOPER'] == True : 
                 logging.debug("Connecting as SYSOPER to the database")
-                self.args['dbcon'] = cx_Oracle.connect(self.args['connectionStr'], mode=cx_Oracle.SYSOPER,threaded=threaded)
+                dsn_tns = cx_Oracle.makedsn(self.args['server'], self.args['port'], self.args['sid'])
+                self.args['dbcon'] = cx_Oracle.connect(user=self.args['user'], password=self.args['password'], mode=cx_Oracle.SYSOPER, dsn=dsn_tns,threaded=threaded)
             else :
-                self.args['dbcon'] = cx_Oracle.connect(self.args['connectionStr'],threaded=threaded)
+                dsn_tns = cx_Oracle.makedsn(self.args['server'], self.args['port'], self.args['sid'])
+                self.args['dbcon'] = cx_Oracle.connect(user=self.args['user'], password=self.args['password'], dsn=dsn_tns,threaded=threaded)
             self.args['dbcon'].autocommit = True
             if self.remoteOS == '' and self.oracleDatabaseversion=='' : self.loadInformationRemoteDatabase() 
             return True

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Usage examples of ODAT:
 
 Tested on Oracle Database __10g__,  __11g__,  __12c__ and __18c__.
 
-__ODAT linux standalone__ version at [https://github.com/quentinhardy/odat/releases/](https://github.com/quentinhardy/odat/releases/). Notice it is recommended to use the development version (*git clone*).
-~~(__Deprecated at this time__)~~
+Compatible with both python 2.7 ([master branch](https://github.com/quentinhardy/odat/tree/master)) and __python 3__ ([master-python3 branch](https://github.com/quentinhardy/odat/tree/master-python3)).
+
+__ODAT linux standalone__ version at [https://github.com/quentinhardy/odat/releases/](https://github.com/quentinhardy/odat/releases/). Notice it is recommended to use the development version (*git clone*), with the [master-python3 branch](https://github.com/quentinhardy/odat/tree/master-python3).
 
 Changelog
 ====

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ __Standalone versions__ exist in order to don't have need to install dependencie
 The ODAT standalone has been generated thanks to *pyinstaller*.
 
 If you want to have the __development version__ installed on your computer, these following tools and dependencies are needed:
-* Langage: Python 2.7
+* Langage: Python 2.7 & Python 3
 * Oracle dependancies: 
   * Instant Oracle basic
   * Instant Oracle sdk


### PR DESCRIPTION
Connection string in OracleDatabase in used to connect to server is parsed by cx_Oracle. It fails when password contains a '@'. This diff modifies the way the connection string is built to support '@' in username and password.